### PR TITLE
Fix IO handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore executables
+bmfdec
+bmfparse
+bmf2mof


### PR DESCRIPTION
This PR fixes the handling of file IO in `bmfdec`,  which caused random errors whenever `read()` encountered a "short read". This usually happened with BMOF data larger than 4096 bytes. It also adds a gitignore file to ignore the executables. 